### PR TITLE
Adding metadata to service discovery

### DIFF
--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -68,6 +68,7 @@ AgentService.prototype.register = function(opts, callback) {
   req.body.Name = opts.name;
   if (opts.id) req.body.ID = opts.id;
   if (opts.tags) req.body.Tags = opts.tags;
+  if (opts.metadata) req.body.Meta = opts.meta;
   if (opts.hasOwnProperty('address')) req.body.Address = opts.address;
   if (opts.hasOwnProperty('port')) req.body.Port = opts.port;
 

--- a/lib/agent/service.js
+++ b/lib/agent/service.js
@@ -68,7 +68,7 @@ AgentService.prototype.register = function(opts, callback) {
   req.body.Name = opts.name;
   if (opts.id) req.body.ID = opts.id;
   if (opts.tags) req.body.Tags = opts.tags;
-  if (opts.metadata) req.body.Meta = opts.meta;
+  if (opts.meta) req.body.Meta = opts.meta;
   if (opts.hasOwnProperty('address')) req.body.Address = opts.address;
   if (opts.hasOwnProperty('port')) req.body.Port = opts.port;
 


### PR DESCRIPTION
## Description

The official library lacks of metadata set for service discovery.

https://www.consul.io/api/agent/service.html#meta

With this change we are adding it and we'll using internally until our changes are incorporated by the official library (in case they are)