### PR TITLE
Implementing proper service registry

### DIFF
--- a/lib/catalog/node.js
+++ b/lib/catalog/node.js
@@ -27,8 +27,6 @@ CatalogNode.prototype.list = function(opts, callback) {
   if (!callback) {
     callback = opts;
     opts = {};
-  } else if (typeof opts === 'string') {
-    opts = { dc: opts };
   }
 
   opts = utils.normalizeKeys(opts);
@@ -38,6 +36,12 @@ CatalogNode.prototype.list = function(opts, callback) {
     name: 'catalog.node.list',
     path: '/catalog/nodes',
   };
+
+  if (opts.filter) {
+    req.query = {
+      filter: opts.filter
+    };
+  }
 
   utils.options(req, opts);
 

--- a/lib/catalog/service.js
+++ b/lib/catalog/service.js
@@ -75,6 +75,70 @@ CatalogService.prototype.nodes = function(opts, callback) {
 };
 
 /**
+ * Registers a new service
+ */
+
+CatalogService.prototype.register = function(opts, callback) {
+  if (typeof opts === 'string') {
+    opts = { name: opts };
+  }
+
+  opts = utils.normalizeKeys(opts);
+  opts = utils.defaults(opts, this.consul._defaults);
+
+  var req = {
+    name: 'catalog.service.register',
+    path: '/catalog/register',
+    type: 'json',
+    body: opts
+  };
+
+  try {
+    if (Array.isArray(opts.checks)) {
+      req.body.Checks = opts.checks.map(utils.createServiceCheck);
+    } else if (opts.check) {
+      req.body.Check = utils.createServiceCheck(opts.check);
+    }
+  } catch (err) {
+    return callback(this.consul._err(errors.Validation(err.message), req));
+  }
+
+  utils.options(req, opts);
+
+  this.consul._put(req, utils.empty, callback);
+};
+
+/**
+ * Deregister a service
+ */
+
+CatalogService.prototype.deregister = function(opts, callback) {
+  if (typeof opts === 'string') {
+    opts = { node: opts };
+  }
+
+  opts = utils.normalizeKeys(opts);
+  opts = utils.defaults(opts, this.consul._defaults);
+
+  var req = {
+    name: 'catalog.service.deregister',
+    path: '/catalog/deregister',
+    type: 'json',
+    body: {},
+  };
+
+  if (!opts.node) {
+    return callback(this.consul._err(errors.Validation('node id required'), req));
+  }
+
+  req.body.Node = opts.node;
+
+  utils.options(req, opts);
+
+  this.consul._put(req, utils.empty, callback);
+};
+
+/**
  * Module Exports.
  */
 


### PR DESCRIPTION
### What

We were wrong about how Consul Register works for service node instances. So far we have relied on the Consul Agent's Register interface which is actually intended to represent instances of Consul Agents itself, not our nodes of our own services.
This is the root cause of the service instances not properly represented (and actually not being propagated on all of the Consul nodes).

Instead of the previous approach we have to use the Consul’s catalog API endpoints and that way our services will be properly represented.

This also provides the benefit that Consul in the UI will represent all of the associated services under the same node.

Sadly this library (the official one) doesn't support either Catalog register/unregister/list filtering therefore we have to extend it including those methods.

### How

- Adding Registering and DeRegistering for service nodes.
- Extending Node list endpoint by including filtering.